### PR TITLE
Fixed depricated code for D9.

### DIFF
--- a/src/FieldOptionGroup.php
+++ b/src/FieldOptionGroup.php
@@ -53,7 +53,7 @@ class FieldOptionGroup {
     $this->options[$option->optionId] = $option;
   }
 
-  public function groupForm(&$member)
+  public function groupForm(&$member, $requireMandatory = TRUE)
   {
     $options = [
       '#type' => 'fieldset',
@@ -76,7 +76,7 @@ class FieldOptionGroup {
           'class' => ['field-option'],
         ],
       ];
-      if (isset($option->mustSelect) && $option->mustSelect == 1) {
+      if (isset($option->mustSelect) && $option->mustSelect == 1 && $requireMandatory) {
         //$options[$option->optionId]['option']['#required'] = TRUE;
         $options[$option->optionId]['option']['#attributes']['class'][] = 'must-select';
       }

--- a/src/FieldOptions.php
+++ b/src/FieldOptions.php
@@ -157,7 +157,7 @@ class FieldOptions {
    * $memberNo - >=1 only show member options. =0 only show Global options. =-1 show global and member options.
    * $member - Member object containing saved member.
    */
-  public function addOptionFields($fieldSet, &$memberForm, Member $member = NULL, $showGlobal = NULL, $showPrivate = FALSE)
+  public function addOptionFields($fieldSet, &$memberForm, Member $member = NULL, $showGlobal = NULL, $showPrivate = FALSE, $requireMandatory = TRUE)
   {
     // Loop through each field option.
     foreach ($this->fieldSets[$fieldSet] as $group) {
@@ -180,7 +180,7 @@ class FieldOptions {
           $memberForm[$group->fieldName][$group->fieldName] = $field;
           $memberForm[$group->fieldName][$group->fieldName]['#attributes']['class'][] = 'field-has-options';
         }
-        $memberForm[$group->fieldName]['options'] = $group->groupForm($member);
+        $memberForm[$group->fieldName]['options'] = $group->groupForm($member, $requireMandatory);
       }
     }
   }

--- a/src/SimpleConregAdminBadgePrint.php
+++ b/src/SimpleConregAdminBadgePrint.php
@@ -10,6 +10,7 @@ namespace Drupal\simple_conreg;
 use Drupal\Core\Form\FormBase;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\File\FileSystemInterface;
+use Drupal\Component\Utility\Html;
 //use Drupal\file\Entity\File;
 use Drupal\devel;
 
@@ -185,6 +186,7 @@ class SimpleConregAdminBadgePrint extends FormBase {
       $member_type = str_replace(' ', '-', isset($memberTypes->types[$member['member_type']]) ? $memberTypes->types[$member['member_type']]->name : $member['member_type']);
       $badge_type = str_replace(' ', '-', isset($badgeTypes[$member['badge_type']]) ? $badgeTypes[$member['badge_type']] : $member['badge_type']);
       $member_no = $member['badge_type'] . sprintf("%0".$digits."d", $member['member_no']);
+      $badge_name = Html::escape($member['badge_name']);
       if (!empty($member['days'])) {
         $dayDescs = [];
         foreach(explode('|', $member['days']) as $day) {
@@ -202,12 +204,12 @@ class SimpleConregAdminBadgePrint extends FormBase {
   <div class="badge-side badge-left">
     <div class="badge-type">'.$badge_type.'</div>
     <div class="badge-number">'.$member_no.'</div>
-    <div id="badge-name-mid'.$member['mid'].'-left" class="badge-name">'.$member['badge_name'].'</div>
+    <div id="badge-name-mid'.$member['mid'].'-left" class="badge-name">'.$badge_name.'</div>
     <div class="badge-days">'.$member_days.'</div>
   </div><div class="badge-side badge-right">
     <div class="badge-type">'.$badge_type.'</div>
     <div class="badge-number">'.$member_no.'</div>
-    <div id="badge-name-mid'.$member['mid'].'-right" class="badge-name">'.$member['badge_name'].'</div>
+    <div id="badge-name-mid'.$member['mid'].'-right" class="badge-name">'.$badge_name.'</div>
     <div class="badge-days">'.$member_days.'</div>
   </div>
 </div>',

--- a/src/SimpleConregAdminMemberAddOns.php
+++ b/src/SimpleConregAdminMemberAddOns.php
@@ -49,7 +49,7 @@ class SimpleConregAdminMemberAddOns extends FormBase {
       $options[$key] = (!empty($val['free']['label']) ? $val['free']['label'] : $val['addon']['label']);
     }
 
-    $tempstore = \Drupal::service('user.private_tempstore')->get('simple_conreg');
+    $tempstore = \Drupal::service('tempstore.private')->get('simple_conreg');
     // If form values submitted, use the display value that was submitted over the passed in values.
     if (isset($form_values['selAddOn']))
       $selection = $form_values['selAddOn'];

--- a/src/SimpleConregAdminMemberDelete.php
+++ b/src/SimpleConregAdminMemberDelete.php
@@ -161,7 +161,7 @@ class SimpleConregAdminMemberDelete extends FormBase {
   public function submitCancel(array &$form, FormStateInterface $form_state) {
     $eid = $form_state->get('eid');
     // Get session state to return to correct page.
-    $tempstore = \Drupal::service('user.private_tempstore')->get('simple_conreg');
+    $tempstore = \Drupal::service('tempstore.private')->get('simple_conreg');
     $display = $tempstore->get('display');
     $page = $tempstore->get('page');
     // Redirect to member list.
@@ -179,7 +179,7 @@ class SimpleConregAdminMemberDelete extends FormBase {
     $member->deleteMember();    
     
     // Get session state to return to correct page.
-    $tempstore = \Drupal::service('user.private_tempstore')->get('simple_conreg');
+    $tempstore = \Drupal::service('tempstore.private')->get('simple_conreg');
     $display = $tempstore->get('display');
     $page = $tempstore->get('page');
     // Redirect to member list.

--- a/src/SimpleConregAdminMemberEdit.php
+++ b/src/SimpleConregAdminMemberEdit.php
@@ -312,8 +312,8 @@ class SimpleConregAdminMemberEdit extends FormBase
     if (is_null($fieldOptions)) {
       $fieldOptions = FieldOptions::getFieldOptions($eid);
     }
-    // Add the field options to the form. Display both global and member fields. Display public and private fields.
-    $fieldOptions->addOptionFields($fieldset, $form['member'], $member, NULL, TRUE);
+    // Add the field options to the form. Display both global and member fields. Display public and private fields. 
+    $fieldOptions->addOptionFields($fieldset, $form['member'], $member, NULL, TRUE, FALSE);
 
     $form['member']['is_paid'] = array(
       '#type' => 'checkbox',
@@ -386,7 +386,7 @@ class SimpleConregAdminMemberEdit extends FormBase
   public function submitCancel(array &$form, FormStateInterface $form_state) {
     $eid = $form_state->get('eid');
     // Get session state to return to correct page.
-    $tempstore = \Drupal::service('user.private_tempstore')->get('simple_conreg');
+    $tempstore = \Drupal::service('tempstore.private')->get('simple_conreg');
     $display = $tempstore->get('display');
     $page = $tempstore->get('page');
     // Redirect to member list.
@@ -540,7 +540,7 @@ class SimpleConregAdminMemberEdit extends FormBase
       }
 
       // Get session state to return to correct page.
-      $tempstore = \Drupal::service('user.private_tempstore')->get('simple_conreg');
+      $tempstore = \Drupal::service('tempstore.private')->get('simple_conreg');
       $display = $tempstore->get('display');
       $page = $tempstore->get('page');
 

--- a/src/SimpleConregAdminMemberEmail.php
+++ b/src/SimpleConregAdminMemberEmail.php
@@ -366,7 +366,7 @@ class SimpleConregAdminMemberEmail extends FormBase {
   public function submitCancel(array &$form, FormStateInterface $form_state) {
     $eid = $form_state->get('eid');
     // Get session state to return to correct page.
-    $tempstore = \Drupal::service('user.private_tempstore')->get('simple_conreg');
+    $tempstore = \Drupal::service('tempstore.private')->get('simple_conreg');
     $display = $tempstore->get('display');
     $page = $tempstore->get('page');
     // Redirect to member list.
@@ -394,7 +394,7 @@ class SimpleConregAdminMemberEmail extends FormBase {
     $language_code = \Drupal::languageManager()->getDefaultLanguage()->getId();
     $send_now = TRUE;
     // Get session state to return to correct page.
-    $tempstore = \Drupal::service('user.private_tempstore')->get('simple_conreg');
+    $tempstore = \Drupal::service('tempstore.private')->get('simple_conreg');
     $display = $tempstore->get('display');
     $page = $tempstore->get('page');
     // Send confirmation email to member.

--- a/src/SimpleConregAdminMemberOptions.php
+++ b/src/SimpleConregAdminMemberOptions.php
@@ -88,7 +88,7 @@ class SimpleConregAdminMemberOptions extends FormBase {
     $group = \Drupal::request()->query->get('group');
     $option = \Drupal::request()->query->get('option');
 
-    $tempstore = \Drupal::service('user.private_tempstore')->get('simple_conreg');
+    $tempstore = \Drupal::service('tempstore.private')->get('simple_conreg');
     // If form values submitted, use the display value that was submitted over the passed in values.
     if (isset($form_values['selOption']))
       $selection = $form_values['selOption'];

--- a/src/SimpleConregAdminMemberTransfer.php
+++ b/src/SimpleConregAdminMemberTransfer.php
@@ -177,7 +177,7 @@ class SimpleConregAdminMemberTransfer extends FormBase {
   public function submitCancel(array &$form, FormStateInterface $form_state) {
     $eid = $form_state->get('eid');
     // Get session state to return to correct page.
-    $tempstore = \Drupal::service('user.private_tempstore')->get('simple_conreg');
+    $tempstore = \Drupal::service('tempstore.private')->get('simple_conreg');
     $display = $tempstore->get('display');
     $page = $tempstore->get('page');
     // Redirect to member list.
@@ -206,7 +206,7 @@ class SimpleConregAdminMemberTransfer extends FormBase {
     }
     
     // Get session state to return to correct page.
-    $tempstore = \Drupal::service('user.private_tempstore')->get('simple_conreg');
+    $tempstore = \Drupal::service('tempstore.private')->get('simple_conreg');
     $display = $tempstore->get('display');
     $page = $tempstore->get('page');
     // Redirect to member list.

--- a/src/SimpleConregAdminMembers.php
+++ b/src/SimpleConregAdminMembers.php
@@ -90,7 +90,7 @@ class SimpleConregAdminMembers extends FormBase {
                 'custom' => $this->t('Custom search'),
                ];
 
-    $tempstore = \Drupal::service('user.private_tempstore')->get('simple_conreg');
+    $tempstore = \Drupal::service('tempstore.private')->get('simple_conreg');
     // If form values submitted, use the display value that was submitted over the passed in values.
     if (isset($form_values['display']))
       $display = $form_values['display'];

--- a/src/SimpleConregController.php
+++ b/src/SimpleConregController.php
@@ -115,7 +115,7 @@ class SimpleConregController extends ControllerBase {
       else
         $key = $member[$order] . $member_no;  // Append member number to ensure uniqueness.
       if (!empty($entry['display']) && $entry['display'] != 'N' && !empty($entry['country'])) {
-        $rows[$key] = array_map('Drupal\Component\Utility\Html::escape', $member);
+        $rows[$key] = $member;
       }
       $total++;
     }
@@ -146,7 +146,7 @@ class SimpleConregController extends ControllerBase {
       if (!empty($entry['country'])) {
         // Sanitize each entry.
         $entry['country'] = trim($countryOptions[$entry['country']]);
-        $rows[] = array_map('Drupal\Component\Utility\Html::escape', (array) $entry);
+        $rows[] = $entry;
         $total += $entry['num'];
       }
     }
@@ -183,7 +183,7 @@ class SimpleConregController extends ControllerBase {
     foreach ($entries = SimpleConregStorage::adminMemberSummaryLoad($eid) as $entry) {
       // Replace type code with description.
       $content['summary'][] = [
-        ['#markup' => Html::escape(isset($types->types[$entry['member_type']]) ? $types->types[$entry['member_type']]->name : $entry['member_type'])],
+        ['#markup' => isset($types->types[$entry['member_type']]) ? $types->types[$entry['member_type']]->name : $entry['member_type']],
         ['#markup' => $entry['num']],
       ];
       $total += $entry['num'];
@@ -216,7 +216,7 @@ class SimpleConregController extends ControllerBase {
     foreach ($entries = SimpleConregStorage::adminMemberBadgeSummaryLoad($eid) as $entry) {
       // Replace type code with description.
       $content['badge_summary'][] = [
-        ['#markup' => Html::escape(isset($types[trim($entry['badge_type'])]) ? $types[trim($entry['badge_type'])] : $entry['badge_type'])],
+        ['#markup' => isset($types[trim($entry['badge_type'])]) ? $types[trim($entry['badge_type'])] : $entry['badge_type']],
         ['#markup' => $entry['num']],
       ];
       $total += $entry['num'];
@@ -261,7 +261,7 @@ class SimpleConregController extends ControllerBase {
     foreach ($dayTotals as $key=>$val) {
       // Sanitize each entry.
       $content['days_summary'][] = [
-        ['#markup' => Html::escape(isset($days[$key]) ? $days[$key] : $key)],
+        ['#markup' => isset($days[$key]) ? $days[$key] : $key],
         ['#markup' => $val],
       ];
     }
@@ -293,7 +293,7 @@ class SimpleConregController extends ControllerBase {
     foreach ($entries = SimpleConregStorage::adminMemberPaymentMethodSummaryLoad($eid) as $entry) {
       // Sanitize each entry.
       $rows[] = [
-        ['#markup' => Html::escape($entry['payment_method'])],
+        ['#markup' => $entry['payment_method']],
         ['#markup' => $entry['num']],
       ];
       $total += $entry['num'];
@@ -376,7 +376,7 @@ class SimpleConregController extends ControllerBase {
       $entry['total_paid'] = number_format($total_paid, 2);
       // Sanitize each entry.
       $rows[] = [
-        ['#markup' => Html::escape(isset($types->types[$entry['member_type']]) ? $types->types[$entry['member_type']]->name : $entry['member_type'])],
+        ['#markup' => isset($types->types[$entry['member_type']]) ? $types->types[$entry['member_type']]->name : $entry['member_type']],
         ['#markup' => $entry['member_price']],
         ['#markup' => $entry['num']],
         ['#markup' => number_format($total_paid, 2)],
@@ -426,8 +426,8 @@ class SimpleConregController extends ControllerBase {
       $total_amount += $entry['total_paid'];
       // Sanitize each entry.
       $rows[] = [
-        ['#markup' => Html::escape($entry['year'])],
-        ['#markup' => Html::escape($entry['month'])],
+        ['#markup' => $entry['year']],
+        ['#markup' => $entry['month']],
         ['#markup' => $entry['num']],
         ['#markup' => number_format($entry['total_paid'], 2)],
         ['#markup' => $total],
@@ -558,7 +558,7 @@ class SimpleConregController extends ControllerBase {
       $entry['is_paid'] = isset($yesNo[$entry['is_paid']]) ? $yesNo[$entry['is_paid']] : $entry['is_paid'];
       $entry['is_approved'] = isset($yesNo[$entry['is_approved']]) ? $yesNo[$entry['is_approved']] : $entry['is_approved'];
       // Sanitize each entry.
-      $rows[] = array_map('Drupal\Component\Utility\Html::escape', (array) $entry);
+      $rows[] = $entry;
     }
     $content['table'] = array(
       '#type' => 'table',
@@ -675,7 +675,7 @@ class SimpleConregController extends ControllerBase {
         $entry['days'] = implode(', ', $dayDescs);
       }
       // Sanitize each entry.
-      $rows[] = array_map('Drupal\Component\Utility\Html::escape', (array) $entry);
+      $rows[] = $entry;
     }
     $content['table'] = array(
       '#type' => 'table',
@@ -698,7 +698,6 @@ class SimpleConregController extends ControllerBase {
     );
 
     $table = 0;
-    $zz9_option = "";
     $rows = array();
     $headers = array(
       t('First Name'),
@@ -714,7 +713,7 @@ class SimpleConregController extends ControllerBase {
     foreach ($entries = SimpleConregStorage::adminMemberAddOns($eid) as $entry) {
       $total += $entry['add_on_price'];
       // Sanitize each entry.
-      $rows[] = array_map('Drupal\Component\Utility\Html::escape', (array) $entry);
+      $rows[] = $entry;
     }
     
     $rows[] = [t('Total'), '', '', '', '', number_format($total, 2)];
@@ -740,7 +739,6 @@ class SimpleConregController extends ControllerBase {
     );
 
     $table = 0;
-    $zz9_option = "";
     $rows = array();
     $headers = array(
       t('Member No'),
@@ -758,7 +756,7 @@ class SimpleConregController extends ControllerBase {
 
     foreach ($entries = SimpleConregStorage::adminMemberChildMembers($eid) as $entry) {
       // Sanitize each entry.
-      $rows[] = array_map('Drupal\Component\Utility\Html::escape', (array) $entry);
+      $rows[] = $entry;
     }
     
     $content['table'] = array(
@@ -768,53 +766,6 @@ class SimpleConregController extends ControllerBase {
       '#empty' => t('No entries available.'),
       '#sticky' => TRUE,
     );
-    // Don't cache this page.
-    $content['#cache']['max-age'] = 0;
-
-    return $content;
-  }
-
-  public function memberAdminZZ9List($eid) {
-    $content = array();
-
-    $content['message'] = array(
-      '#markup' => $this->t('Here is a list of all Lazlar Lyricon 3 members of ZZ9.'),
-    );
-
-    $table = 0;
-    $zz9_option = "";
-    $rows = array();
-    $headers = array(
-      t('First Name'),
-      t('Last Name'),
-      t('Email'),
-      t('Badge Name'),
-      t('Street'),
-      t('City'),
-      t('County'),
-      t('Postcode'),
-      t('Country'),
-      t('Phone'),
-      t('Birth Date'),
-      t('ZZ9 No'),
-      t('Allow Committee'),
-      t('Allow Members'),
-    );
-
-    foreach ($entries = SimpleConregStorage::adminZZ9MemberListLoad($eid) as $entry) {
-      if ($zz9_option != $entry['add_on']) {
-        if (!empty($zz9_option)) {
-          $this->memberAdminZZ9ListTable($content, $zz9_option, $headers, $rows, $table++);
-          $rows = array();
-        }
-        $zz9_option = $entry['add_on'];
-      }
-      // Take out the ZZ9 Option column.
-      unset($entry['add_on']);
-      // Sanitize each entry.
-      $rows[] = array_map('Drupal\Component\Utility\Html::escape', (array) $entry);
-    }
-    $this->memberAdminZZ9ListTable($content, $zz9_option, $headers, $rows, $table++);
     // Don't cache this page.
     $content['#cache']['max-age'] = 0;
 
@@ -845,7 +796,7 @@ class SimpleConregController extends ControllerBase {
 
     foreach ($entries = SimpleConregStorage::adminProgrammeMemberListLoad($eid) as $entry) {
       // Sanitize each entry.
-      $rows[] = array_map('Drupal\Component\Utility\Html::escape', (array) $entry);
+      $rows[] = $entry;
     }
     $content['table'] = array(
       '#type' => 'table',
@@ -883,7 +834,7 @@ class SimpleConregController extends ControllerBase {
 
     foreach ($entries = SimpleConregStorage::adminVolunteerMemberListLoad($eid) as $entry) {
       // Sanitize each entry.
-      $rows[] = array_map('Drupal\Component\Utility\Html::escape', (array) $entry);
+      $rows[] = $entry;
     }
     $content['table'] = array(
       '#type' => 'table',
@@ -894,54 +845,6 @@ class SimpleConregController extends ControllerBase {
     // Don't cache this page.
     $content['#cache']['max-age'] = 0;
 
-    return $content;
-  }
-
-  public function memberAdminZZ9ListTable(&$content, $zz9_option, $headers, $rows, $tableNo) {
-    $content['heading'.$tableNo] = array(
-      '#markup' => '<h2>'.$zz9_option.'</h2>',
-    );
-    $content['table'.$tableNo] = array(
-      '#type' => 'table',
-      '#header' => $headers,
-      '#rows' => $rows,
-      '#empty' => t('No entries available.'),
-    );
-  }
-
-  /**
-   * Render a filtered list of entries in the database.
-   */
-  public function entryAdvancedList() {
-    $content = array();
-
-    $content['message'] = array(
-      '#markup' => $this->t('A more complex list of entries in the database.') . ' ' .
-      $this->t('Only the entries with name = "John" and age older than 18 years are shown, the username of the person who created the entry is also shown.'),
-    );
-
-    $headers = array(
-      t('Id'),
-      t('Created by'),
-      t('Name'),
-      t('Surname'),
-      t('Age'),
-    );
-
-    $rows = array();
-    foreach ($entries = SimpleConregStorage::advancedLoad() as $entry) {
-      // Sanitize each entry.
-      $rows[] = array_map('Drupal\Component\Utility\Html::escape', $entry);
-    }
-    $content['table'] = array(
-      '#type' => 'table',
-      '#header' => $headers,
-      '#rows' => $rows,
-      '#attributes' => array('id' => 'dbtng-example-advanced-list'),
-      '#empty' => t('No entries available.'),
-    );
-    // Don't cache this page.
-    $content['#cache']['max-age'] = 0;
     return $content;
   }
 

--- a/src/SimpleConregMemberEdit.php
+++ b/src/SimpleConregMemberEdit.php
@@ -373,7 +373,7 @@ class SimpleConregMemberEdit extends FormBase {
   {
     $eid = $form_state->get('eid');
     // Get session state to return to correct page.
-    $tempstore = \Drupal::service('user.private_tempstore')->get('simple_conreg');
+    $tempstore = \Drupal::service('tempstore.private')->get('simple_conreg');
     $display = $tempstore->get('display');
     $page = $tempstore->get('page');
     // Redirect to member list.
@@ -427,7 +427,7 @@ class SimpleConregMemberEdit extends FormBase {
     if ($return) {
 
       // Get session state to return to correct page.
-      $tempstore = \Drupal::service('user.private_tempstore')->get('simple_conreg');
+      $tempstore = \Drupal::service('tempstore.private')->get('simple_conreg');
       $display = $tempstore->get('display');
       $page = $tempstore->get('page');
 


### PR DESCRIPTION
Fixed deprecation issues.
Removed Html::escape from tables where double escaping was occurring.
Added Html::escape to badge printing.
Removed old ZZ9 reports.
Fixed admin member edit form so admins can complete form without checking mandatory options.