### PR TITLE
Small fixes

### DIFF
--- a/js/conreg_disable_on_click.js
+++ b/js/conreg_disable_on_click.js
@@ -1,0 +1,17 @@
+(function ($) {
+  'use strict';
+
+  Drupal.behaviors.disableOnClick = {
+    attach: function (context, settings) {
+
+      $('.disable-on-click', context).on('click', function(event) {
+        $(event.target).prop('disabled', true);
+        let button_text = $(event.target).text();
+        $(event.target).html(button_text + ' <img src="/core/misc/throbber-active.gif">');
+        $(event.target).parents('form').submit();
+      });
+
+    }
+  };
+
+}(jQuery));

--- a/js/conreg_select_all.js
+++ b/js/conreg_select_all.js
@@ -1,0 +1,32 @@
+(function ($) {
+  'use strict';
+
+  Drupal.behaviors.disableOnClick = {
+    attach: function (context, settings) {
+
+      // Function to check "select all" if all checkboxes are selected.
+      function checkAllSelected() {
+        let allSelected = true;
+        $('.checkbox-selectable').each(function(check) {
+          if (!this.checked) allSelected = false;
+        });
+        $('.select-all').prop('checked', allSelected);
+      }
+
+      // Check initial state (if all checkboxes checked, check all should start checked).
+      checkAllSelected();
+
+      // Function to check all checkboxes when "select all" checked.
+      $('.select-all', context).on('click', function(event) {
+        $('.checkbox-selectable').prop('checked', event.target.checked);
+      });
+
+      // Function to update "select all" when checkboxes change. Set to checked if all checkboxes checked, otherwise unchecked.
+      $('.checkbox-selectable').on('click', function() {
+        checkAllSelected();
+      });
+
+    }
+  };
+
+}(jQuery));

--- a/simple_conreg.libraries.yml
+++ b/simple_conreg.libraries.yml
@@ -66,7 +66,15 @@ conreg_admin:
   css:
     theme:
       css/simple_conreg_admin.css: {}
-  
+
+conreg_select_all:
+  version: 1.x
+  js:
+    js/conreg_select_all.js: {}
+  dependencies:
+    - core/drupal.form
+    - core/jquery
+
 conreg_disable_on_click:
   version: 1.x
   js:

--- a/simple_conreg.libraries.yml
+++ b/simple_conreg.libraries.yml
@@ -67,3 +67,10 @@ conreg_admin:
     theme:
       css/simple_conreg_admin.css: {}
   
+conreg_disable_on_click:
+  version: 1.x
+  js:
+    js/conreg_disable_on_click.js: {}
+  dependencies:
+    - core/drupal.form
+    - core/jquery

--- a/src/Form/EventAddOnsForm.php
+++ b/src/Form/EventAddOnsForm.php
@@ -153,7 +153,7 @@ class EventAddOnsForm extends ConfigFormBase
       $form['addons'][$addOnId]['info']['label'] = array(
         '#type' => 'textfield',
         '#title' => $this->t('Label'),
-        '#description' => t('If you would like to capture optional information about the add-on, please provide label and description for the information field.'),
+        '#description' => $this->t('If you would like to capture optional information about the add-on, please provide label and description for the information field.'),
         '#default_value' => (isset($info['label']) ? $info['label'] : ''),
       );  
 

--- a/src/Form/EventMemberClassesForm.php
+++ b/src/Form/EventMemberClassesForm.php
@@ -239,6 +239,7 @@ class EventMemberClassesForm extends ConfigFormBase
         '#type' => 'submit',
         '#value' => $this->t('Delete @name', ['@name' => $className]),
         '#submit' => [[$this, 'deleteSubmit']],
+        '#limit_validation_errors' => [],
         '#attributes' => array('id' => "submitBtn"),
       );
 
@@ -278,6 +279,7 @@ class EventMemberClassesForm extends ConfigFormBase
     $form['cancel'] = array(
       '#type' => 'submit',
       '#value' => $this->t('Cancel'),
+      '#limit_validation_errors' => [],
       '#submit' => [[$this, 'cancelAction']],
     );
     return parent::buildForm($form, $form_state);
@@ -309,6 +311,7 @@ class EventMemberClassesForm extends ConfigFormBase
     $form['cancel'] = array(
       '#type' => 'submit',
       '#value' => $this->t('Cancel'),
+      '#limit_validation_errors' => [],
       '#submit' => [[$this, 'cancelAction']],
     );
     return parent::buildForm($form, $form_state);

--- a/src/Form/EventMemberTypesForm.php
+++ b/src/Form/EventMemberTypesForm.php
@@ -166,6 +166,7 @@ class EventMemberTypesForm extends ConfigFormBase
         '#type' => 'submit',
         '#value' => $this->t('Delete @name', ['@name' => $typeName]),
         '#submit' => [[$this, 'deleteSubmit']],
+        '#limit_validation_errors' => [],
         '#attributes' => ['id' => "submitBtn"],
       ];
     }
@@ -209,6 +210,7 @@ class EventMemberTypesForm extends ConfigFormBase
     $form['cancel'] = [
       '#type' => 'submit',
       '#value' => $this->t('Cancel'),
+      '#limit_validation_errors' => [],
       '#submit' => [[$this, 'cancelAction']],
     ];
     return parent::buildForm($form, $form_state);
@@ -240,6 +242,7 @@ class EventMemberTypesForm extends ConfigFormBase
     $form['cancel'] = [
       '#type' => 'submit',
       '#value' => $this->t('Cancel'),
+      '#limit_validation_errors' => [],
       '#submit' => [[$this, 'cancelAction']],
     ];
     return parent::buildForm($form, $form_state);

--- a/src/SimpleConregAdminMemberEdit.php
+++ b/src/SimpleConregAdminMemberEdit.php
@@ -332,7 +332,7 @@ class SimpleConregAdminMemberEdit extends FormBase
     $form['member']['member_price'] = array(
       '#type' => 'number',
       '#title' => $this->t('Price'),
-      '#default_value' => (isset($member->member_price) ? $member->member_price : ''),
+      '#default_value' => (isset($member->member_price) ? $member->member_price : '0'),
       '#step' => '0.01',
     );
 
@@ -370,6 +370,7 @@ class SimpleConregAdminMemberEdit extends FormBase
     $form['cancel'] = array(
       '#type' => 'submit',
       '#value' => t('Cancel'),
+      '#limit_validation_errors' => [],
       '#submit' => [[$this, 'submitCancel']],
     );
 
@@ -380,10 +381,23 @@ class SimpleConregAdminMemberEdit extends FormBase
   }
 
   /*
+   * Validate form on submit.
+   */
+
+  public function validateForm(array &$form, FormStateInterface $form_state)
+  {
+    $form_values = $form_state->getValues();
+    if ($form_values['member']['member_price'] == '' || !is_numeric($form_values['member']['member_price'])) {
+      $form_state->setErrorByName('member][member_price', $this->t('Member price must be a number.'));
+    }
+  }
+
+  /*
    * Submit handler for cancel button.
    */
 
-  public function submitCancel(array &$form, FormStateInterface $form_state) {
+  public function submitCancel(array &$form, FormStateInterface $form_state)
+  {
     $eid = $form_state->get('eid');
     // Get session state to return to correct page.
     $tempstore = \Drupal::service('tempstore.private')->get('simple_conreg');
@@ -397,7 +411,8 @@ class SimpleConregAdminMemberEdit extends FormBase
    * Submit handler for member edit form.
    */
 
-  public function submitForm(array &$form, FormStateInterface $form_state) {
+  public function submitForm(array &$form, FormStateInterface $form_state)
+  {
     $eid = $form_state->get('eid');
     $mid = $form_state->get('mid');
     $curMemberClassRef = $form_state->get('member_class');

--- a/src/SimpleConregAdminMemberEdit.php
+++ b/src/SimpleConregAdminMemberEdit.php
@@ -364,12 +364,12 @@ class SimpleConregAdminMemberEdit extends FormBase
 
     $form['payment']['submit'] = array(
       '#type' => 'submit',
-      '#value' => t('Save member'),
+      '#value' => $this->t('Save member'),
     );
 
     $form['cancel'] = array(
       '#type' => 'submit',
-      '#value' => t('Cancel'),
+      '#value' => $this->t('Cancel'),
       '#limit_validation_errors' => [],
       '#submit' => [[$this, 'submitCancel']],
     );
@@ -527,17 +527,17 @@ class SimpleConregAdminMemberEdit extends FormBase
             // Get communications methods selected for newsletter.
             $communications_methods = $simplenews_options[$newsletter_id]['communications_methods'];
             // Check if member matches newsletter criteria.
-            if (isset($entry['email']) && $entry['email'] != '') {
-              if (isset($entry['communication_method']) &&
-                  isset($communications_methods[$entry['communication_method']]) &&
-                  $communications_methods[$entry['communication_method']]) {
+            if (isset($member->email) && $member->email != '') {
+              if (isset($member->communication_method) &&
+                  isset($communications_methods[$member->communication_method]) &&
+                  $communications_methods[$member->communication_method]) {
                 // Subscribe member if criteria met.
-                $subscription_manager->subscribe($entry['email'], $newsletter_id, FALSE, 'website');
-                \Drupal::messenger()->addMessage($this->t('Subscribed %email to %newsletter.', ['%email' => $entry['email'], '%newsletter' => $newsletter_id]));
+                $subscription_manager->subscribe($member->email, $newsletter_id, FALSE, 'website');
+                \Drupal::messenger()->addMessage($this->t('Subscribed %email to %newsletter.', ['%email' => $member->email, '%newsletter' => $newsletter_id]));
               } else {
                 // Unsubscribe member if criteria not met (their communications method may have changed).
-                $subscription_manager->unsubscribe($entry['email'], $newsletter_id, FALSE, 'website');
-                \Drupal::messenger()->addMessage($this->t('Unsubscribed %email from %newsletter.', ['%email' => $entry['email'], '%newsletter' => $newsletter_id]));
+                $subscription_manager->unsubscribe($member->email, $newsletter_id, FALSE, 'website');
+                \Drupal::messenger()->addMessage($this->t('Unsubscribed %email from %newsletter.', ['%email' => $member->email, '%newsletter' => $newsletter_id]));
               }
             }
           }

--- a/src/SimpleConregAdminMembers.php
+++ b/src/SimpleConregAdminMembers.php
@@ -16,24 +16,28 @@ use Drupal\Core\Ajax\HtmlCommand;
 use Drupal\Core\Link;
 use Drupal\Core\Url;
 use Drupal\Component\Utility\Html;
+use Drupal\Core\Render\RendererInterface;
 use Drupal\devel;
 
 /**
  * Simple form to add an entry, with all the interesting fields.
  */
-class SimpleConregAdminMembers extends FormBase {
+class SimpleConregAdminMembers extends FormBase
+{
 
   /**
    * {@inheritdoc}
    */
-  public function getFormID() {
+  public function getFormID()
+  {
     return 'simple_conreg_admin_members';
   }
 
   /**
    * {@inheritdoc}
    */
-  public function buildForm(array $form, FormStateInterface $form_state, $eid = 1, $display = NULL, $page = NULL) {
+  public function buildForm(array $form, FormStateInterface $form_state, $eid = 1, $display = NULL, $page = NULL)
+  {
     // Store Event ID in form state.
     $form_state->set('eid', $eid);
 
@@ -111,73 +115,82 @@ class SimpleConregAdminMembers extends FormBase {
       $search = $tempstore->get('search');
     $tempstore->set('search', $search);
 
-    $form = array(
+    $form = [
       '#attached' => [
-        'library' => ['simple_conreg/conreg_tables'],
+        'library' => [
+          'simple_conreg/conreg_select_all',
+          'simple_conreg/conreg_tables',
+        ],
       ],
       '#prefix' => '<div id="memberform">',
       '#suffix' => '</div>',
-    );
+    ];
 
     $form['add_link'] = Link::createFromRoute($this->t('Add new member'), 'simple_conreg_admin_members_add', ['eid' => $eid])->toRenderable();
     $form['add_link']['#attributes'] = ['class' => ['button', 'button-action', 'button--primary', 'button--small']];
 
-    $form['display'] = array(
+    $form['display'] = [
       '#type' => 'select',
       '#title' => $this->t('Select '),
       '#options' => $options,
       '#default_value' => $display,
       '#required' => TRUE,
-      '#ajax' => array(
+      '#ajax' => [
         'wrapper' => 'memberform',
-        'callback' => array($this, 'updateDisplayCallback'),
+        'callback' => [$this, 'updateDisplayCallback'],
         'event' => 'change',
-      ),
-    );
+      ],
+    ];
 
-    $headers = array(
-      'first_name' => ['data' => t('First name'), 'field' => 'm.first_name'],
-      'last_name' => ['data' => t('Last name'), 'field' => 'm.last_name'],
-      'email' => ['data' => t('Email'), 'field' => 'm.email'],
-      'badge_name' => ['data' => t('Badge name'), 'field' => 'm.badge_name'],
-      'display' =>  ['data' => t('Display'), 'class' => [RESPONSIVE_PRIORITY_LOW]],
-      'member_type' =>  ['data' => t('Member type'), 'class' => [RESPONSIVE_PRIORITY_LOW]],
-      'days' =>  ['data' => t('Days'), 'class' => [RESPONSIVE_PRIORITY_LOW]],
-      'badge_type' =>  ['data' => t('Badge type'), 'class' => [RESPONSIVE_PRIORITY_LOW]],
-      t('Paid'),
-      t('Approved'),
-      'member_no' => ['data' => t('Member no'), 'field' => 'm.member_no', 'sort' => 'asc'],
-      t('Update'),
-    );
+    $headers = [
+      'first_name' => ['data' => $this->t('First name'), 'field' => 'm.first_name'],
+      'last_name' => ['data' => $this->t('Last name'), 'field' => 'm.last_name'],
+      'email' => ['data' => $this->t('Email'), 'field' => 'm.email'],
+      'badge_name' => ['data' => $this->t('Badge name'), 'field' => 'm.badge_name'],
+      'display' =>  ['data' => $this->t('Display')],
+      'member_type' =>  ['data' => $this->t('Member type')],
+      'days' =>  ['data' => $this->t('Days')],
+      'badge_type' =>  ['data' => $this->t('Badge type')],
+      $this->t('Paid'),
+      $this->t('Approved'),
+      'member_no' => ['data' => $this->t('Member no'), 'field' => 'm.member_no', 'sort' => 'asc'],
+      $this->t('Update'),
+    ];
 
     // If display 
     if ($display == 'custom') {
-      $form['search'] = array(
+      $form['search'] = [
         '#type' => 'textfield',
         '#title' => $this->t('Custom search term'),
         '#default_value' => trim($search),
-      );
+      ];
       
-      $form['search_button'] = array(
+      $form['search_button'] = [
         '#type' => 'button',
-        '#value' => t('Search'),
-        '#attributes' => array('id' => "searchBtn"),
-        '#validate' => array(),
-        '#submit' => array('::search'),
-        '#ajax' => array(
+        '#value' => $this->t('Search'),
+        '#attributes' => ['id' => "searchBtn"],
+        '#validate' => [],
+        '#submit' => ['::search'],
+        '#ajax' => [
           'wrapper' => 'memberform',
-          'callback' => array($this, 'updateDisplayCallback'),
-        ),
-      );
+          'callback' => [$this, 'updateDisplayCallback'],
+        ],
+      ];
     }
 
-    $form['table'] = array(
+    $form['select_all'] = [
+      '#type' => 'checkbox',
+      '#title' => $this->t('Select all'),
+      '#attributes' => ['class' => ['select-all']],
+    ];
+
+    $form['table'] = [
       '#type' => 'table',
       '#header' => $headers,
-      '#attributes' => array('id' => 'simple-conreg-admin-member-list'),
-      '#empty' => t('No entries available.'),
+      '#attributes' => ['id' => 'simple-conreg-admin-member-list'],
+      '#empty' => $this->t('No entries available.'),
       '#sticky' => TRUE,
-    );      
+    ];
 
     if ($display != 'custom')
       list($pages, $entries) = SimpleConregStorage::adminMemberListLoad($eid, $display, NULL, $page, $pageSize, $order, $direction);
@@ -206,26 +219,26 @@ class SimpleConregAdminMembers extends FormBase {
       $mid = $entry['mid'];
       // Sanitize each entry.
       $is_paid = $entry['is_paid'];
-      $row = array();
-      $row['first_name'] = array(
+      $row = [];
+      $row['first_name'] = [
         '#markup' => Html::escape($entry['first_name']),
-      );
-      $row['last_name'] = array(
+      ];
+      $row['last_name'] = [
         '#markup' => Html::escape($entry['last_name']),
-      );
-      $row['email'] = array(
+      ];
+      $row['email'] = [
         '#markup' => Html::escape($entry['email']),
-      );
-      $row['badge_name'] = array(
+      ];
+      $row['badge_name'] = [
         '#markup' => Html::escape($entry['badge_name']),
-      );
-      $row['display'] = array(
+      ];
+      $row['display'] = [
         '#markup' => Html::escape(isset($displayOptions[$entry['display']]) ? $displayOptions[$entry['display']] : $entry['display']),
-      );
+      ];
       $memberType = trim($entry['member_type']);
-      $row['member_type'] = array(
+      $row['member_type'] = [
         '#markup' => Html::escape(isset($types->types[$memberType]->name) ? $types->types[$memberType]->name : $memberType),
-      );
+      ];
       if (!empty($entry['days'])) {
         $dayDescs = [];
         foreach(explode('|', $entry['days']) as $day) {
@@ -234,62 +247,64 @@ class SimpleConregAdminMembers extends FormBase {
         $memberDays = implode(', ', $dayDescs);
       } else
         $memberDays = '';
-      $row['days'] = array(
+      $row['days'] = [
         '#markup' => Html::escape($memberDays),
-      );
+      ];
       $badgeType = trim($entry['badge_type']);
-      $row['badge_type'] = array(
+      $row['badge_type'] = [
         '#markup' => Html::escape(isset($badgeTypes[$badgeType]) ? $badgeTypes[$badgeType] : $badgeType),
-      );
-      $row['is_paid'] = array(
+      ];
+      $row['is_paid'] = [
         '#markup' => $is_paid ? $this->t('Yes') : $this->t('No'),
-      );
-      $row["is_approved"] = array(
-        //'#attributes' => array('name' => 'is_approved_'.$mid, 'id' => 'edit_is_approved_'.$mid),
+      ];
+      $row["is_approved"] = [
+        //'#attributes' => ['name' => 'is_approved_'.$mid, 'id' => 'edit_is_approved_'.$mid),
         '#type' => 'checkbox',
-        '#title' => t('Is Approved'),
+        '#title' => $this->t('Is Approved'),
         '#title_display' => 'invisible',
         '#default_value' => $entry['is_approved'],
-      );
-      if (empty($entry["member_no"]))
+        '#attributes' => ['class' => ['checkbox-selectable']],
+      ];
+      if (empty($entry["member_no"])) {
         $entry["member_no"] = "";
-        $row["member_no"] = array(
-          '#type' => 'textfield',
-          '#title' => t('Member No'),
-          '#title_display' => 'invisible',
-          '#size' => 5,
-          '#default_value' => $entry['member_no'],
-      );
-      $row['link'] = array(
+      }
+      $row["member_no"] = [
+        '#type' => 'textfield',
+        '#title' => $this->t('Member No'),
+        '#title_display' => 'invisible',
+        '#size' => 5,
+        '#default_value' => $entry['member_no'],
+      ];
+      $row['link'] = [
         '#type' => 'dropbutton',
-        '#links' => array(
-          'edit_button' => array(
+        '#links' => [
+          'edit_button' => [
             'title' => $this->t('Edit'),
             'url' => Url::fromRoute('simple_conreg_admin_members_edit', ['eid' => $eid, 'mid' => $mid]),
-          ),
-          'delete_button' => array(
+          ],
+          'delete_button' => [
             'title' => $this->t('Delete'),
             'url' => Url::fromRoute('simple_conreg_admin_members_delete', ['eid' => $eid, 'mid' => $mid]),
-          ),
-          'transfer_button' => array(
+          ],
+          'transfer_button' => [
             'title' => $this->t('Transfer'),
             'url' => Url::fromRoute('simple_conreg_admin_members_transfer', ['eid' => $eid, 'mid' => $mid]),
-          ),
-          'email_button' => array(
+          ],
+          'email_button' => [
             'title' => $this->t('Send email'),
             'url' => Url::fromRoute('simple_conreg_admin_members_email', ['eid' => $eid, 'mid' => $mid]),
-          ),
-        ),
-      );
+          ],
+        ],
+      ];
 
       $form['table'][$mid] = $row;
     }
     
-    $form['pager'] = array(
+    $form['pager'] = [
       '#markup' => $this->t('Page:'),
       '#prefix' => '<div id="pager">',
       '#suffix' => '</div>',
-    );
+    ];
     for ($p = 1; $p <= $pages; $p++) {
       if ($p == $page)
         $form['pager']['page'.$p]['#markup'] = $p;
@@ -299,22 +314,23 @@ class SimpleConregAdminMembers extends FormBase {
       $form['pager']['page'.$p]['#suffix'] = '</span> ';
     }
 
-    $form['submit'] = array(
+    $form['submit'] = [
       '#type' => 'submit',
-      '#value' => t('Save Changes'),
-      '#attributes' => array('id' => "submitBtn"),
-    );
+      '#value' => $this->t('Save Changes'),
+      '#attributes' => ['id' => "submitBtn"],
+    ];
     return $form;
   }
 
   // Callback function for "member type" and "add-on" drop-downs. Replace price fields.
-  public function updateApprovedCallback(array $form, FormStateInterface $form_state) {
+  public function updateApprovedCallback(array $form, FormStateInterface $form_state)
+  {
     $triggering_element = $form_state->getTriggeringElement();
     $ajax_response = new AjaxResponse();
     if (preg_match("/table\[(\d+)\]\[is_approved\]/", $triggering_element['#name'], $matches)) {
       $mid = $matches[1];
       $form['table'][$mid]["member_div"]["member_no"]['#value'] = $triggering_element['#value'];
-      $ajax_response->addCommand(new HtmlCommand('#member_no_'.$mid, render($form['table'][$mid]["member_div"]["member_no"]['#value'])));
+      $ajax_response->addCommand(new HtmlCommand('#member_no_'.$mid, RendererInterface::render($form['table'][$mid]["member_div"]["member_no"]['#value'])));
       //$ajax_response->addCommand(new AlertCommand($row." = ".));
     }
     return $ajax_response;

--- a/src/SimpleConregRegistrationForm.php
+++ b/src/SimpleConregRegistrationForm.php
@@ -137,7 +137,11 @@ class SimpleConregRegistrationForm extends FormBase {
       '#prefix' => '<div id="regform">',
       '#suffix' => '</div>',
       '#attached' => [
-        'library' => ['simple_conreg/conreg_form', 'simple_conreg/conreg_fieldoptions'],
+        'library' => [
+          'simple_conreg/conreg_form',
+          'simple_conreg/conreg_fieldoptions',
+          'simple_conreg/conreg_disable_on_click'
+        ],
         'drupalSettings' => [],
       ],
     ];
@@ -570,7 +574,10 @@ class SimpleConregRegistrationForm extends FormBase {
     $form['payment']['submit'] = [
       '#type' => 'submit',
       '#value' => $submitLabel,
-      '#attributes' => ['id' => 'edit-payment-submit'],
+      '#attributes' => [
+        'id' => 'edit-payment-submit',
+        'class' => ['disable-on-click'],
+      ],
       '#prefix' => '<div id="Submit">',
       '#suffix' => '</div>',
     ];


### PR DESCRIPTION
Assorted small fixes:
- [Prevent duplicate submits from registration form.](https://github.com/lostcarpark/simple_conreg/commit/1e62a4abb053273e3c26c5d7fc2c7262d2c6e2b4)
- [Require numeric member price on member. Allow cancel when invalid.](https://github.com/lostcarpark/simple_conreg/commit/e74282e7ebab5cdb0c068c5addbd4253962f71c5)
- [Add 'select all' checkbox to member admin.](https://github.com/lostcarpark/simple_conreg/commit/a8d2148cd1f7a3511b850163bddab672558b9eb1)
- [Fix t() on Add Ons form.](https://github.com/lostcarpark/simple_conreg/commit/24680974151931b311b84508f34378e8d53d0ac4)
- [Fix t() in Member Edit form, and update SimpleNews to use member object.](https://github.com/lostcarpark/simple_conreg/commit/24cb6456326f1ffbdf9f7a94c4b1e6f1dd3d57de)
- [Allow cancel buttons on Class and Type admin pages to skip vlidation.](https://github.com/lostcarpark/simple_conreg/commit/84f1b9792d4b458119b6dfb38313b628a8931a42)