### PR TITLE
Removed static country list to use Drupal CountryManager

### DIFF
--- a/simple_conreg.install
+++ b/simple_conreg.install
@@ -779,3 +779,11 @@ function simple_conreg_schema() {
 
   return $schema;
 }
+
+function simple_conreg_update_9001() {
+  foreach (\Drupal::configFactory()->listAll('simple_conreg.settings') as $key) {
+    $config = \Drupal::configFactory()->getEditable($key);
+    $config->clear("reference.countries");
+    $config->save();
+  }
+}

--- a/src/Form/EventConfigForm.php
+++ b/src/Form/EventConfigForm.php
@@ -311,7 +311,8 @@ class EventConfigForm extends ConfigFormBase {
     );  
 
     /*
-     * Fields for reference data - countries list.
+     * Fields for reference data.
+     * Used to contain countries list, but now using standard Drupal list.
      */
 
     $form['simple_conreg_reference'] = array(
@@ -320,14 +321,7 @@ class EventConfigForm extends ConfigFormBase {
       '#tree' => TRUE,
       '#group' => 'admin',
     );
-
-    $form['simple_conreg_reference']['countries'] = array(
-      '#type' => 'textarea',
-      '#title' => $this->t('Country list'),
-      '#description' => $this->t('Put each country on a line with 2-letter country code and name separated by | character.'),
-      '#default_value' => $config->get('reference.countries'),
-    );  
-        
+  
     $form['simple_conreg_reference']['default_country'] = array(
       '#type' => 'textfield',
       '#title' => $this->t('Default country code'),
@@ -629,7 +623,6 @@ class EventConfigForm extends ConfigFormBase {
     $config->set('simple_conreg_options.options', $vals['simple_conreg_options']['options']);
     $config->set('display.page_size', intval($vals['simple_conreg_display']['page_size']));
     $config->set('reference.default_country', $vals['simple_conreg_reference']['default_country']);
-    $config->set('reference.countries', $vals['simple_conreg_reference']['countries']);
     $config->set('reference.no_country_label', $vals['simple_conreg_reference']['no_country_label']);
     $config->set('reference.geoplugin', $vals['simple_conreg_reference']['geoplugin']);
     $config->set('submit.payment', $vals['simple_conreg_submit']['submit_payment']);

--- a/src/Member.php
+++ b/src/Member.php
@@ -200,7 +200,7 @@ class Member
 
       case 'country':
         $countryOptions = SimpleConregOptions::memberCountries($this->eid, $config);
-        return isset($countryOptions[$this->country]) ? $countryOptions[$this->country] : $this->country;
+        return $countryOptions[$this->country] ?: $this->country;
 
       case 'join_date':
         return date('Y-m-d H:i:s', $this->join_date);

--- a/src/SimpleConregRegistrationForm.php
+++ b/src/SimpleConregRegistrationForm.php
@@ -116,7 +116,6 @@ class SimpleConregRegistrationForm extends FormBase
     $memberClasses = SimpleConregOptions::memberClasses($eid, $config);
     $symbol = $config->get('payments.symbol');
     $countryOptions = SimpleConregOptions::memberCountries($eid, $config);
-    $countryOptions = SimpleConregOptions::memberCountries($eid, $config);
     $defaultCountry = $config->get('reference.default_country');
     // If geoPlugin enabled in configuration, lookup country.
     if ($config->get('reference.geoplugin')) {

--- a/src/SimpleConregRegistrationForm.php
+++ b/src/SimpleConregRegistrationForm.php
@@ -116,6 +116,7 @@ class SimpleConregRegistrationForm extends FormBase
     $memberClasses = SimpleConregOptions::memberClasses($eid, $config);
     $symbol = $config->get('payments.symbol');
     $countryOptions = SimpleConregOptions::memberCountries($eid, $config);
+    $countryOptions = SimpleConregOptions::memberCountries($eid, $config);
     $defaultCountry = $config->get('reference.default_country');
     // If geoPlugin enabled in configuration, lookup country.
     if ($config->get('reference.geoplugin')) {


### PR DESCRIPTION
Internal list of countries no longer needed.
Removed from reference section of config page.
Removed from memberCountries.
Replaced with Drupal CountryManager getList function.