### PR TITLE
Change cache to key by event id and language.

### DIFF
--- a/src/FieldOptions.php
+++ b/src/FieldOptions.php
@@ -74,16 +74,18 @@ class FieldOptions
    */
   public static function getFieldOptions($eid, $reset = false)
   {
-    $cid = 'simple_conreg:fieldOptions_' . $eid;
+    $language = \Drupal::languageManager()->getCurrentLanguage()->getId();
+    $cid = 'simple_conreg:fieldOptions_' . $eid . '_' . $language;
 
-    $fieldOptions = NULL;
+    // Check if field options previously cached.
     if (!$reset && $cache = \Drupal::cache()->get($cid)) {
-      $fieldOptions = $cache->data;
+      return $cache->data;
     }
-    else {
-      $fieldOptions = new FieldOptions($eid);
-      \Drupal::cache()->set($cid, $fieldOptions);
-    }
+
+    // Not cached, so create new field options, and cache that.
+    $fieldOptions = new FieldOptions($eid);
+    \Drupal::cache()->set($cid, $fieldOptions);
+
     return $fieldOptions;
   }
 

--- a/src/SimpleConregOptions.php
+++ b/src/SimpleConregOptions.php
@@ -459,13 +459,13 @@ class SimpleConregOptions
    *
    * Parameters: Optional config.
    */
-  public static function memberCountries($eid, &$config = NULL)
+  public static function memberCountries($eid, &$config = NULL, $reset = FALSE)
   {
-    static $countryLists = [];
-    
+    $language = \Drupal::languageManager()->getCurrentLanguage()->getId();
+    $cid = 'simple_conreg:countryList_' . $eid . '_' . $language;
     // Check if previously used country list available.
-    if (array_key_exists($eid, $countryLists)) {
-      return $countryLists[$eid];
+    if (!$reset && $cache = \Drupal::cache()->get($cid)) {
+      return $cache->data;
     }
     if (is_null($config)) {
       $config = SimpleConregConfig::getConfig($eid);
@@ -480,7 +480,7 @@ class SimpleConregOptions
     $countryOptions = empty($noCountryLabel) ? $countries : [0 => $noCountryLabel, ...$countries];
 
     // Cache for future use.
-    $countryLists[$eid] = $countryOptions;
+    \Drupal::cache()->set($cid, $countryOptions);
     return $countryOptions;
   }
 


### PR DESCRIPTION
Was caching member options, but only keyed by event id. This caused whichever language was cached to be read for all languages. Changed cache to key by event ID and language.
Also added Countries list to cache, also keyed by event ID and language.