### PR TITLE
Delete cached data for all languages on config save.

### DIFF
--- a/src/Form/EventConfigForm.php
+++ b/src/Form/EventConfigForm.php
@@ -655,7 +655,12 @@ class EventConfigForm extends ConfigFormBase {
     $config->set('member_edit.badge_name_editable', $vals['simple_conreg_member_edit']['badge_name']);
     $config->save();
 
-    FieldOptions::getFieldOptions($eid, true);
+    $langcodes = \Drupal::languageManager()->getLanguages();
+    foreach ($langcodes as $language) {
+      $langCode = $language->getId();
+      \Drupal::cache()->delete('simple_conreg:countryList_' . $eid . '_' . $langCode);
+      \Drupal::cache()->delete('simple_conreg:fieldOptions_' . $eid . '_' . $langCode);
+    }
 
     parent::submitForm($form, $form_state);
   }

--- a/src/SimpleConregAddons.php
+++ b/src/SimpleConregAddons.php
@@ -211,9 +211,9 @@ class SimpleConregAddons
 
     foreach ($addOns as $addOnId => $addOnVals) {
       // If add-on set, get values.
-      $addon = (isset($addOnVals['addon']) ? $addOnVals['addon'] : []);          
+      $addon = ($addOnVals['addon'] ?? []);          
       // Check add-on is enabled.
-      if ($addon['active'] == 1) {
+      if (($addon['active'] ?? 0) == 1) {
         // Get add options...
         list($addOnOptions, $addOnPrices) = self::memberAddons($addon['options']);
         // If global is set, only display if there's a member number.


### PR DESCRIPTION
Loop through all active languages, and delete cached settings for country list and field options for each language.