### PR TITLE
Fixed setting language when saving member.

### DIFF
--- a/src/SimpleConregAdminMailoutEmails.php
+++ b/src/SimpleConregAdminMailoutEmails.php
@@ -75,9 +75,9 @@ class SimpleConregAdminMailoutEmails extends FormBase {
     );
 
     $fieldOptions = [
-      'name' => 'Show name',
-      'method' => 'Communications method',
-      'language' => 'Language',
+      'name' => $this->t('Name'),
+      'method' => $this->t('Communications method'),
+      'language' => $this->t('Language'),
     ];
     $form['fields'] = array(
       '#type' => 'checkboxes',

--- a/src/SimpleConregRegistrationForm.php
+++ b/src/SimpleConregRegistrationForm.php
@@ -949,6 +949,7 @@ class SimpleConregRegistrationForm extends FormBase
         'member_total' => $memberPrices[$cnt]->price,
         'add_on_price' => $memberPrices[$cnt]->addOnPrice,
         'payment_amount' => $totalPrice,
+        'language' => $language,
         'join_date' => time(),
         'update_date' => time(),
       ];


### PR DESCRIPTION
Missed a line when saving member language.
Also left out t() wrappers on additional field checkbox labels.