### PR TITLE
Store Stripe Session ID in payment sessions table.

### DIFF
--- a/simple_conreg.install
+++ b/simple_conreg.install
@@ -559,14 +559,6 @@ function simple_conreg_schema() {
         'default' => 0,
         'description' => 'Unix timestamp for the date and time member was upgraded.',
       ),
-      // alter table conreg_payments add session_id varchar(255) after created_date;
-      'session_id' => array(
-        'type' => 'varchar',
-        'length' => 255,
-        'not null' => FALSE,
-        'default' => '',
-        'description' => 'Stripe Session ID.',
-      ),
       'paid_date' => array(
         'type' => 'int',
         'not null' => TRUE,
@@ -598,6 +590,36 @@ function simple_conreg_schema() {
     ),
     'primary key' => array('payid'),
   );
+
+  // Payment Sessions table, used to store Stripe session keys.
+  $schema['conreg_payment_sessions'] = [
+    'description' => 'Stores member upgrades.',
+    'fields' => [
+      'paysessionid' => [
+        'type' => 'serial',
+        'not null' => TRUE,
+        'description' => 'Primary Key: Unique payment session ID.',
+      ],
+      'payid' => [
+        'type' => 'int',
+        'not null' => TRUE,
+        'default' => 0,
+        'description' => "Payment ID that the session belongs to.",
+      ],
+      'session_id' => [
+        'type' => 'varchar',
+        'length' => 255,
+        'not null' => FALSE,
+        'default' => '',
+        'description' => 'Stripe Session ID.',
+      ],
+    ],
+    'primary key' => ['paysessionid'],
+    'indexes' => [
+      'idx_conreg_payment_sessions_payid' => ['payid'],
+      'idx_conreg_payment_sessions_session_id' => ['session_id'],
+    ]
+  ];
 
   // create table conreg_payment_lines (lineid int auto_increment primary key, payid int not null, mid int not null, payment_type varchar(255) not null, line_desc varchar(255) not null, amount numeric(10,2) not null);
   $schema['conreg_payment_lines'] = array(
@@ -806,4 +828,82 @@ function simple_conreg_update_9002() {
   ); 
   $schema = Database::getConnection()->schema();
   $schema->addField('conreg_members', 'language', $spec);
+}
+
+/**
+ * Add payment sessions table.
+ * Move Stripe session ID from payments table to payment sessions.
+ * Drop session ID from payments table.
+ */
+function simple_conreg_update_9003()
+{
+  $conreg_payment_sessions = array(
+    'description' => 'Stores member upgrades.',
+    'fields' => array(
+      'paysessionid' => array(
+        'type' => 'serial',
+        'not null' => TRUE,
+        'description' => 'Primary Key: Unique payment session ID.',
+      ),
+      'payid' => array(
+        'type' => 'int',
+        'not null' => TRUE,
+        'default' => 0,
+        'description' => "Payment ID that the session belongs to.",
+      ),
+      'session_id' => array(
+        'type' => 'varchar',
+        'length' => 255,
+        'not null' => FALSE,
+        'default' => '',
+        'description' => 'Stripe Session ID.',
+      ),
+    ),
+    'primary key' => array('paysessionid'),
+  );
+  $db = Database::getConnection();
+  $schema = $db->schema();
+  $schema->createTable('conreg_payment_sessions', $conreg_payment_sessions);
+  $db->query('INSERT INTO {conreg_payment_sessions} (payid, session_id) SELECT payid, session_id FROM {conreg_payments}');
+  $schema->dropField('conreg_payments', 'session_id');
+}
+
+/**
+ * Add indexes to payment sessions table.
+ */
+function simple_conreg_update_9004()
+{
+  $conreg_payment_sessions = [
+    'description' => 'Stores member upgrades.',
+    'fields' => [
+      'paysessionid' => [
+        'type' => 'serial',
+        'not null' => TRUE,
+        'description' => 'Primary Key: Unique payment session ID.',
+      ],
+      'payid' => [
+        'type' => 'int',
+        'not null' => TRUE,
+        'default' => 0,
+        'description' => "Payment ID that the session belongs to.",
+      ],
+      'session_id' => [
+        'type' => 'varchar',
+        'length' => 255,
+        'not null' => FALSE,
+        'default' => '',
+        'description' => 'Stripe Session ID.',
+      ],
+    ],
+    'primary key' => ['paysessionid'],
+    'indexes' => [
+      'idx_conreg_payment_sessions_payid' => ['payid'],
+      'idx_conreg_payment_sessions_session_id' => ['session_id'],
+    ]
+  ];
+
+  $db = Database::getConnection();
+  $schema = $db->schema();
+  $schema->addIndex('conreg_payment_sessions', 'idx_conreg_payment_sessions_payid', ['payid'], $conreg_payment_sessions);
+  $schema->addIndex('conreg_payment_sessions', 'idx_conreg_payment_sessions_session_id', ['session_id'], $conreg_payment_sessions);
 }

--- a/src/SimpleConregCheckoutForm.php
+++ b/src/SimpleConregCheckoutForm.php
@@ -214,11 +214,11 @@ class SimpleConregCheckoutForm extends FormBase
     ]);
 
     // Loop through received events and mark payments complete.
-    foreach ($events->autoPagingIterator() as $event) {
-      $session = $event->data->object;
+    foreach ($events->data as $event) {
+      $session = ((object)$event)->data->object;
       // Update the payment record.
       $payment = SimpleConregPayment::loadBySessionId($session->id);
-      if (isset($payment)) {
+      if (!is_null($payment)) {
         // Only update payment if not already paid.
         if (empty($payment->paidDate)) {
           $payment->paidDate = time();
@@ -296,6 +296,7 @@ class SimpleConregCheckoutForm extends FormBase
     $params['subject'] = $config->get('confirmation.template_subject');
     $params['body'] = $config->get('confirmation.template_body');
     $params['body_format'] = $config->get('confirmation.template_format');
+    $params['include_private'] = true;
     $module = "simple_conreg";
     $key = "template";
     $to = $member["email"];
@@ -308,6 +309,7 @@ class SimpleConregCheckoutForm extends FormBase
     // If copy_us checkbox checked, send a copy to us.
     if ($config->get('confirmation.copy_us')) {
       $params['subject'] = $config->get('confirmation.notification_subject');
+      $params['include_private'] = false;
       $to = $config->get('confirmation.from_email');
       $result = $this->mailManager->mail($module, $key, $to, $language_code, $params);
     }
@@ -315,6 +317,7 @@ class SimpleConregCheckoutForm extends FormBase
     // If copy email to field provided, send an extra copy to us.
     if (!empty($config->get('confirmation.copy_email_to'))) {
       $params['subject'] = $config->get('confirmation.notification_subject');
+      $params['include_private'] = false;
       $to = $config->get('confirmation.copy_email_to');
       $result = $this->mailManager->mail($module, $key, $to, $language_code, $params);
     }

--- a/src/SimpleConregStripe.php
+++ b/src/SimpleConregStripe.php
@@ -20,7 +20,7 @@ class SimpleConregStripe
 
         // Loop through received events and mark payments complete.
         foreach ($events->autoPagingIterator() as $event) {
-            $session = $event->data->object;
+            $session = ((object)$event)->data->object;
             // Update the payment record.
             $payment = SimpleConregPayment::loadBySessionId($session->id);
             if (isset($payment)) {


### PR DESCRIPTION
Add new payment sessions table and store Stripe session ID there. This will prevent occasional missed payments where multiple sessions got associated with a payment, and only the most recent session ID was stored.