### PR TITLE
Allow children first member when logged in.

### DIFF
--- a/src/Member.php
+++ b/src/Member.php
@@ -86,6 +86,35 @@ class Member extends \stdClass {
   }
 
   /**
+   * Load a member by their email address.
+   *
+   * @param int $eid
+   *   Event ID.
+   * @param string $email
+   *   Email of member.
+   *
+   * @return Member|null
+   *   The member object.
+   */
+  public static function loadMemberByEmail(int $eid, string $email): Member|NULL {
+    $row = SimpleConregStorage::load([
+      'eid' => $eid,
+      'email' => $email,
+      'is_deleted' => 0,
+    ]);
+    if (empty($row)) {
+      return NULL;
+    }
+
+    $member = self::newMember($row);
+
+    // Add member options to member object.
+    $member->options = MemberOption::loadAllMemberOptions($member->mid);
+
+    return $member;
+  }
+
+  /**
    * Save the member to the conreg_members table.
    *
    * @return int


### PR DESCRIPTION
Normally children can only register with an adult as the first member.
However, if the user is logged in and has a member registered, children may be selected as first member.
When submitting, the logged in member will be the lead member.