### PR TITLE
Bugfix member save cause by StringTranslation trait.

### DIFF
--- a/src/Member.php
+++ b/src/Member.php
@@ -138,7 +138,7 @@ class Member extends \stdClass {
     // Transfer object members into array.
     $entry = [];
     foreach ($this as $field => $value) {
-      if (!is_array($value) && !is_object($value)) {
+      if (!is_array($value) && !is_object($value) && $field != 'stringTranslation') {
         $entry[$field] = $value;
       }
     }


### PR DESCRIPTION
Bug introduced by adding StringTranslationTrait to Member class. Fix was to exclude stringTranslation property when saving.