### PR TITLE
Missed namespace on referenced classes.

### DIFF
--- a/src/Controller/BulkMailController.php
+++ b/src/Controller/BulkMailController.php
@@ -5,6 +5,8 @@ namespace Drupal\simple_conreg\Controller;
 use Drupal\Core\Controller\ControllerBase;
 use Drupal\Core\Language\LanguageManagerInterface;
 use Drupal\Core\Mail\MailManagerInterface;
+use Drupal\simple_conreg\SimpleConregConfig;
+use Drupal\simple_conreg\SimpleConregStorage;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**


### PR DESCRIPTION
When moving bulk email sender to own controller, forgot to include use statements for SimpleConregConfig and SimpleConregStorage.