### PR TITLE
Fix issue with adding and paying from checkin page.

### DIFF
--- a/simple_conreg.routing.yml
+++ b/simple_conreg.routing.yml
@@ -98,6 +98,19 @@ simple_conreg_checkout:
   options:
     no_cache: true
 
+simple_conreg_checkin_checkout:
+  path: 'members/checkin/checkout/{payid}/{key}'
+  defaults:
+    _title: 'Payment'
+    _form: '\Drupal\simple_conreg\SimpleConregCheckoutForm'
+    return: 'checkin'
+  requirements:
+    _permission: 'convention registration'
+    payid: ^[0-9]+$
+    key: ^[0-9]+$
+  options:
+    no_cache: true
+
 simple_conreg_fantable_checkout:
   path: 'members/fantable/checkout/{payid}/{key}'
   defaults:

--- a/src/SimpleConregAdminCheckIn.php
+++ b/src/SimpleConregAdminCheckIn.php
@@ -8,6 +8,7 @@ use Drupal\Core\Form\FormBase;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Session\AccountProxyInterface;
 use Drupal\Component\Utility\Html;
+use Drupal\Core\Language\LanguageManagerInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
@@ -16,21 +17,15 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 class SimpleConregAdminCheckIn extends FormBase {
 
   /**
-   * The database connection.
-   *
-   * @var \Drupal\Core\Session\AccountProxyInterface
-   */
-  protected AccountProxyInterface $currentUser;
-
-  /**
    * Constructor for member lookup form.
    *
    * @param \Drupal\Core\Session\AccountProxyInterface $currentUser
    *   The database connection.
    */
-  public function __construct(AccountProxyInterface $currentUser) {
-    $this->currentUser = $currentUser;
-  }
+  public function __construct(
+    protected AccountProxyInterface $currentUser,
+    protected LanguageManagerInterface $languageManager,
+  ) {}
 
   /**
    * {@inheritdoc}
@@ -39,7 +34,8 @@ class SimpleConregAdminCheckIn extends FormBase {
     // Instantiates this form class.
     return new static(
       // Load the service required to construct this class.
-      $container->get('current_user')
+      $container->get('current_user'),
+      $container->get('language_manager'),
     );
   }
 
@@ -563,6 +559,7 @@ class SimpleConregAdminCheckIn extends FormBase {
     $types = SimpleConregOptions::memberTypes($eid, $config);
     $days = SimpleConregOptions::days($eid, $config);
     $form_values = $form_state->getValues();
+    $language = $this->languageManager->getDefaultLanguage()->getId();
     // Assign random key for payment URL.
     $rand_key = mt_rand();
     if (!empty($form_values['unpaid']['add']['badge_name'])) {
@@ -610,6 +607,7 @@ class SimpleConregAdminCheckIn extends FormBase {
       'payment_amount' => $price,
       'join_date' => time(),
       'update_date' => time(),
+      'language' => $language,
     ];
     // Insert to database table.
     $return = SimpleConregStorage::insert($entry);


### PR DESCRIPTION
When adding a new member from the checkin form, form throws an error that Language field is not set. Fixed by setting to the site's default language when saving.

When clicking "Pay credit card", was throwing error because "simple_conreg_checkin_checkout" route did not exist. Fixed by adding route pointing at the checkout form.