### PR TITLE
Use hook_user_login to set memberroles.

### DIFF
--- a/simple_conreg.module
+++ b/simple_conreg.module
@@ -9,13 +9,14 @@
 
 use Drupal\Core\Routing\RouteMatchInterface;
 use Drupal\Core\Form\FormStateInterface;
-use Drupal\Component\Utility\SafeMarkup;
-use Drupal\devel;
+use Drupal\simple_conreg\Member;
 use Drupal\simple_conreg\SimpleConregEventStorage;
 use Drupal\simple_conreg\SimpleConregStorage;
 use Drupal\simple_conreg\SimpleConregOptions;
 use Drupal\simple_conreg\SimpleConregEmailer;
 use Drupal\simple_conreg\SimpleConregConfig;
+use Drupal\user\UserInterface;
+
 
 function simple_conreg_help($route_name, RouteMatchInterface $route_match)
 {
@@ -142,5 +143,35 @@ function simple_conreg_page_attachments(&$variables) {
   // Include Icon CSS if Drupal earlier than 11.1 - after this use Icon API.
   if (version_compare(\Drupal::VERSION, '11.1', '<')) {
     $variables['#attached']['library'][] = 'simple_conreg/icon';
+  }
+}
+
+/**
+ * Implements hook_user_login().
+ */
+function simple_conreg_user_login(UserInterface $account) {
+  $email = $account->getEmail();
+  if (is_null($email)) {
+    // User is anonymous, so no permissions to add.
+  }
+  // Get the list of all events.
+  $events = SimpleConregEventStorage::loadAll();
+  foreach ($events as $event) {
+    $eid = $event['eid'];
+    $config = SimpleConregConfig::getConfig($eid);
+    // Get the role for the event.
+    $add_role = $config->get('member_portal.add_role');
+    if ($add_role) {
+      // Check if user has role already.
+      if (!$account->hasRole($add_role)) {
+        // Check if account is member of event.
+        $member = Member::loadMemberByEmail($eid, $email);
+        if (!is_null($member)) {
+          // They don't, so we need to add it.
+          $account->addRole($add_role);
+          $account->save();
+        }
+      }
+    }
   }
 }

--- a/src/Controller/LoginController.php
+++ b/src/Controller/LoginController.php
@@ -132,18 +132,6 @@ class LoginController extends ControllerBase {
       $user->save();
     }
 
-    // Check if role needs to be added.
-    $config = SimpleConregConfig::getConfig($member['eid']);
-    $addRole = $config->get('member_portal.add_role');
-    if ($addRole) {
-      // Check if user has role already.
-      if (!$user->hasRole($addRole)) {
-        // They don't, so we need to add it.
-        $user->addRole($addRole);
-        $user->save();
-      }
-    }
-
     // Login user.
     user_login_finalize($user);
 

--- a/src/SimpleConregCheckoutForm.php
+++ b/src/SimpleConregCheckoutForm.php
@@ -237,6 +237,8 @@ class SimpleConregCheckoutForm extends FormBase {
   }
 
   private function processPaymentLine($line, $session) {
+    $config = SimpleConregConfig::getConfig($this->eid);
+
     switch ($line->type) {
       case "member":
         // Only update member if not already paid.
@@ -256,6 +258,17 @@ class SimpleConregCheckoutForm extends FormBase {
           // If email address populated, send confirmation email.
           if (!empty($member->email))
             $this->sendConfirmationEmail((array)$member);
+          // Check if event has a role to add to user account.
+          $add_role = $config->get('member_portal.add_role');
+          if ($add_role) {
+            $account = user_load_by_mail($member->email);
+            // Check if user has role already.
+            if ($account && !$account->hasRole($add_role)) {
+              // They don't, so we need to add it.
+              $account->addRole($add_role);
+              $account->save();
+            }
+          }
         }
         break;
       case "upgrade":


### PR DESCRIPTION
Previously, user only received the convention assigned role if they logged in to the member portal with "check membership".

This change will assign the user role with `hook_user_login` which gets called no matter how they log in.

It will also assign the role if a logged in user complete payment for their membership, so they don't need to log out to get the role.